### PR TITLE
Define `process.env.DRAGGABLE_DEBUG` at build time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## Unreleased
 
+### Fixed
+
+- Fixed a crash when moving the crop selection in webpack 5/browser consumers without a `process` global.
+
 ## [1.0.0](https://github.com/dbmdz/mirador-imagecropper/releases/tag/1.0.0) - 2026-06-24
 
 ### Changed

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,6 +27,13 @@ const pluginConfig = {
       },
     },
   },
+  // react-draggable is bundled into the published library via react-rnd, and
+  // reads process.env.DRAGGABLE_DEBUG during drag start. Vite lib builds leave
+  // that reference intact, which crashes in webpack 5/browser consumers without
+  // a `process` global. Replace the debug flag at build time.
+  define: {
+    "process.env.DRAGGABLE_DEBUG": "false",
+  },
   plugins: [react()],
   server: {
     open: true,

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,6 +27,7 @@ const pluginConfig = {
       },
     },
   },
+  // FIXME: remove this as soon https://github.com/react-grid-layout/react-draggable/issues/806 is fixed
   // react-draggable is bundled into the published library via react-rnd, and
   // reads process.env.DRAGGABLE_DEBUG during drag start. Vite lib builds leave
   // that reference intact, which crashes in webpack 5/browser consumers without


### PR DESCRIPTION
## Purpose

When the published package is bundled into a consumer application with webpack 5, moving the crop selection throws in the browser:

```
ReferenceError: process is not defined
```

The published library bundle includes `react-draggable` via `react-rnd`. On drag start, `react-draggable` reads `process.env.DRAGGABLE_DEBUG`. In webpack 5/browser consumers without a `process` global, that throws.

Vite library builds leave this reference in the output as `process.env.DRAGGABLE_DEBUG && console.log(...)`, so the npm-consumed build can crash when moving the crop selection.

An upstream fix exists in react-grid-layout/react-draggable#810, but it is still open and unreleased, so this package needs a local build-time workaround for now.

## Approach

Add a Vite `define` entry to the plugin build that statically replaces `process.env.DRAGGABLE_DEBUG` with `false`, compiling the dead debug branch out of the published output.

Verified that after `npm run build:plugin` the `DRAGGABLE_DEBUG` reference is gone from `dist/index.js`.